### PR TITLE
feat(analytics): integrate Dreamdata with consent management

### DIFF
--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -107,6 +107,7 @@
               </p>
               <ul class="text-xs text-gray-500 list-disc list-inside space-y-1">
                 <li>Google Analytics (anonymous statistics)</li>
+                <li>Dreamdata (marketing attribution and pipeline analytics)</li>
                 <li>Page views and user journeys</li>
               </ul>
             </div>
@@ -366,6 +367,25 @@ function loadRB2B() {
   }
 }
 
+  // Signal Dreamdata (loaded in <head>) to initialise via its dataLayer interceptor.
+  // The sentinel in Layout.astro sets google_tag_data so Dreamdata waits for this signal.
+  function loadDreamdata() {
+    if (getCookie(ANALYTICS_COOKIE) === 'true') {
+      (window as any).dataLayer = (window as any).dataLayer || [];
+      (window as any).dataLayer.push(['consent', 'update', { analytics_storage: 'granted' }]);
+    }
+  }
+
+  // Load Dreamdata CL (client-side attribution fallback) only after analytics consent.
+  function loadDreamdataCL() {
+    if (getCookie(ANALYTICS_COOKIE) !== 'true') return;
+    if (document.getElementById('dreamdata-analytics-cl')) return;
+    const s = document.createElement('script');
+    s.id = 'init-dreamdata-cl-consent';
+    s.textContent = `!function(){if(!window.dreamdata||!window.dreamdata.initialized){if(window.dreamdata){var e=document.getElementById("dreamdata-analytics");if(e&&e.type&&"text/javascript"==e.type)return}var a="dreamdata-cl",dreamdata=window[a]=window[a]||[];if(!dreamdata.initialize)if(dreamdata.invoked)window.console&&console.error&&console.error("Dreamdata CL snippet included twice.");else{dreamdata.invoked=!0,dreamdata.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","screen","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware","register"],dreamdata.factory=function(e){return function(){if(window[a].initialized)return window[a][e].apply(window[a],arguments);var t=Array.prototype.slice.call(arguments);if(["track","screen","alias","group","page","identify"].indexOf(e)>-1){var r=document.querySelector("link[rel='canonical']");t.push({__t:"bpc",c:r&&r.getAttribute("href")||void 0,p:location.pathname,u:location.href,s:location.search,t:document.title,r:document.referrer})}return t.unshift(e),dreamdata.push(t),dreamdata}};for(var t=0;t<dreamdata.methods.length;t++){var r=dreamdata.methods[t];dreamdata[r]=dreamdata.factory(r)}dreamdata.load=function(e,t){var r=document.createElement("script");r.id="dreamdata-analytics-cl",r.type="text/javascript",r.async=!0,r.setAttribute("data-global-dreamdata-cl-analytics-key",a),r.src="https://cdn.drda.io/scripts/analytics/next/dreamdata.cl.min.js";var i=document.getElementsByTagName("script")[0];i.parentNode.insertBefore(r,i),dreamdata._loadOptions=t},dreamdata._writeKey="9012df46-e34f-460c-b512-e80da56dbfbf",dreamdata.SNIPPET_VERSION="dreamdata-cl-2.0.0",dreamdata.load("9012df46-e34f-460c-b512-e80da56dbfbf"),dreamdata.page()}}}();`;
+    document.head.appendChild(s);
+  }
+
   function loadAllScripts() {
     loadAnalytics();
     loadHubSpot();
@@ -373,6 +393,8 @@ function loadRB2B() {
     loadLinkedIn();
     loadClay();
     loadRB2B();
+    loadDreamdata();
+    loadDreamdataCL();
   }
 
   // Event listeners
@@ -390,6 +412,9 @@ function loadRB2B() {
     setCookie(ANALYTICS_COOKIE, 'false');
     setCookie(MARKETING_COOKIE, 'false');
     hideBanner();
+    // Signal Dreamdata that analytics consent was denied
+    (window as any).dataLayer = (window as any).dataLayer || [];
+    (window as any).dataLayer.push(['consent', 'update', { analytics_storage: 'denied' }]);
     window.dispatchEvent(new CustomEvent('cookie-consent-changed', { detail: { all: false } }));
   });
 
@@ -410,6 +435,11 @@ function loadRB2B() {
     setCookie(ANALYTICS_COOKIE, analyticsCheckbox.checked.toString());
     setCookie(MARKETING_COOKIE, marketingCheckbox.checked.toString());
     hideSettingsModal();
+    // Propagate analytics consent decision to Dreamdata's dataLayer interceptor
+    (window as any).dataLayer = (window as any).dataLayer || [];
+    (window as any).dataLayer.push(['consent', 'update', {
+      analytics_storage: analyticsCheckbox.checked ? 'granted' : 'denied'
+    }]);
     loadAllScripts();
     window.dispatchEvent(new CustomEvent('cookie-consent-changed', { 
       detail: { 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -167,6 +167,22 @@ const finalCanonicalUrl = canonicalUrl || `${SITE_URL}${Astro.url.pathname}`;
       });
     </script>
     <slot name="head" />
+
+    <!-- Dreamdata: consent sentinel prevents auto-init before explicit consent is given.
+         By setting window.google_tag_data with analytics_storage.update: false, Dreamdata
+         enters its dataLayer-intercept mode and waits for a consent signal rather than
+         initialising immediately. -->
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      if (!window.google_tag_data) {
+        window.google_tag_data = { ics: { entries: { analytics_storage: { update: false } } } };
+      }
+    </script>
+
+    <!-- Dreamdata Analytics (consent-aware init) -->
+    <script id="init-dreamdata" is:inline>
+      !function(){"use strict";var a="dreamdata",t="dreamdata-analytics",e=!1;function i(a){if(function(){try{var a=window&&window.localStorage&&window.localStorage.getItem("DD_DEBUGGER");return"true"===a||"1"===a}catch(a){return!1}}())try{var t=window.console,e=Array.prototype.slice.call(arguments,1),i=t&&t[a]?t[a]:t&&t.log?t.log:null;i&&i.apply(t,e)}catch(a){return}}var dreamdata=window[a]=window[a]||[];if(!dreamdata.initialize)if(dreamdata.invoked)i("warn","Dreamdata snippet included twice.");else{dreamdata.invoked=!0,dreamdata.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","screen","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware","register"],dreamdata.factory=function(t){return function(){if(window[a].initialized)return window[a][t].apply(window[a],arguments);var e=Array.prototype.slice.call(arguments);if(["track","screen","alias","group","page","identify"].indexOf(t)>-1){var i=document.querySelector("link[rel='canonical']");e.push({__t:"bpc",c:i&&i.getAttribute("href")||void 0,p:location.pathname,u:location.href,s:location.search,t:document.title,r:document.referrer})}return e.unshift(t),dreamdata.push(e),dreamdata}};for(var r=0;r<dreamdata.methods.length;r++){var n=dreamdata.methods[r];dreamdata[n]=dreamdata.factory(n)}dreamdata.load=function(e,i){var r=document.createElement("script");r.id=t,r.type="text/javascript",r.async=!0,r.setAttribute("data-global-dreamdata-analytics-key",a),r.src="https://cdn.dreamdata.cloud/scripts/analytics/next/dreamdata.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(r,n),dreamdata._loadOptions=i},dreamdata._writeKey="9012df46-e34f-460c-b512-e80da56dbfbf",dreamdata.SNIPPET_VERSION="dreamdata-2.2.6",dreamdata.init=function(){try{if(e)return void i("warn","Dreamdata already initialized, skipping duplicate initialization");dreamdata.load("9012df46-e34f-460c-b512-e80da56dbfbf", {"googleEnhancedConversions":true,"formTracking":{"html":true,"hubspot":true},"intentSources":{"autoGroup":true}}),dreamdata.page(),e=!0}catch(a){i("error","Failed to initialize Dreamdata:",a&&a.message)}},function(){try{if(e)return;if(i("log","✅ dataLayer",window.dataLayer),i("log","✅ google_tag_data",window.google_tag_data),!window.dataLayer||!window.google_tag_data)return void dreamdata.init();if(window.google_tag_data&&window.google_tag_data.ics&&window.google_tag_data.ics.entries&&window.google_tag_data.ics.entries.analytics_storage&&!0===window.google_tag_data.ics.entries.analytics_storage.update||function(){try{var a=localStorage.getItem("framerCookiesConsentMode");if(!a)return!1;var t=JSON.parse(a);return!!t&&!0===t.analytics}catch(a){return!1}}())return i("log","✅ Consent with GTM analytics_storage in google_tag_data granted, initializing Dreamdata"),void dreamdata.init();var a=window.dataLayer.push;window.dataLayer.push=function(){var r=Array.prototype.slice.call(arguments);i("log","✅ DataLayer Change Detected:",r[0]);var n=r[0];return n&&3===n.length&&"consent"===n[0]&&n[2]&&n[2].analytics_storage&&("denied"===n[2].analytics_storage&&(i("log","❌ Consent with GTM analytics_storage in dataLayer denied, removing Dreamdata script"),function(){e=!1;var a=document.getElementById(t);a&&a.remove()}()),"granted"===n[2].analytics_storage&&(i("log","✅ Consent with GTM analytics_storage in dataLayer granted, initializing Dreamdata"),dreamdata.init())),a.apply(this,r)}}catch(a){i("error","Error in initialization logic, falling back to basic init:",a&&a.message),dreamdata.init()}}()}}();
+    </script>
   </head>
   
   <body class="font-sans">

--- a/src/pages/cookie-policy.astro
+++ b/src/pages/cookie-policy.astro
@@ -41,8 +41,9 @@ import Footer from '../components/Footer.astro';
             <p class="mb-4">Help us understand how visitors interact with our website.</p>
             <ul class="list-disc pl-6">
               <li><strong>Google Analytics:</strong> Tracks page views, session duration, and user behavior</li>
-              <li><strong>Purpose:</strong> Improve website performance and user experience</li>
-              <li><strong>Data collected:</strong> Anonymous usage statistics</li>
+              <li><strong>Dreamdata:</strong> Marketing attribution and pipeline analytics — tracks which channels and touchpoints drive pipeline and revenue</li>
+              <li><strong>Purpose:</strong> Improve website performance and measure marketing effectiveness</li>
+              <li><strong>Data collected:</strong> Anonymous usage statistics, page views, form interactions, and attribution data</li>
             </ul>
           </div>
 
@@ -89,6 +90,7 @@ import Footer from '../components/Footer.astro';
           <ul class="list-disc pl-6 mb-4">
             <li><strong>HubSpot:</strong> <a href="https://legal.hubspot.com/privacy-policy" class="text-primary-600 hover:underline">Privacy Policy</a></li>
             <li><strong>Google Analytics:</strong> <a href="https://policies.google.com/privacy" class="text-primary-600 hover:underline">Privacy Policy</a></li>
+            <li><strong>Dreamdata:</strong> <a href="https://dreamdata.io/privacy-policy" class="text-primary-600 hover:underline">Privacy Policy</a></li>
             <li><strong>LinkedIn:</strong> <a href="https://www.linkedin.com/legal/privacy-policy" class="text-primary-600 hover:underline">Privacy Policy</a></li>
             <li><strong>Apollo.io:</strong> <a href="https://www.apollo.io/privacy" class="text-primary-600 hover:underline">Privacy Policy</a></li>
             <li><strong>RB2B:</strong> <a href="https://www.rb2b.com/privacy-policy" class="text-primary-600 hover:underline">Privacy Policy</a></li>

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -79,8 +79,8 @@ import Footer from '../components/Footer.astro';
           <p class="mb-4">Required for the website to function properly. These cannot be disabled.</p>
           
           <h3 class="text-xl font-semibold mb-3">Analytics Cookies</h3>
-          <p class="mb-4">Help us understand how visitors use our website (Google Analytics).</p>
-          
+          <p class="mb-4">Help us understand how visitors use our website and measure marketing effectiveness (Google Analytics, Dreamdata).</p>
+
           <h3 class="text-xl font-semibold mb-3">Marketing Cookies</h3>
           <p class="mb-4">Used to track visitors for advertising purposes (Apollo.io, LinkedIn Insights, Google Ads, Clay, RB2B).</p>
           
@@ -91,7 +91,7 @@ import Footer from '../components/Footer.astro';
           <h2 class="text-2xl font-semibold text-gray-900 mb-4">5. Data Sharing and Disclosure</h2>
           <p class="mb-4">We may share your information with:</p>
           <ul class="list-disc pl-6 mb-4">
-            <li><strong>Service Providers:</strong> Third-party tools and platforms we use (Google Analytics, HubSpot, Apollo.io, Clay, RB2B, email providers)</li>
+            <li><strong>Service Providers:</strong> Third-party tools and platforms we use (Google Analytics, Dreamdata, HubSpot, Apollo.io, Clay, RB2B, email providers)</li>
             <li><strong>Professional Advisors:</strong> Lawyers, accountants, and other professional service providers</li>
             <li><strong>Legal Requirements:</strong> When required by law or to protect our rights</li>
           </ul>


### PR DESCRIPTION
Add Dreamdata analytics and attribution scripts to every page via Layout.astro, gated behind the existing cookie consent system.

- Add consent sentinel (dataLayer + google_tag_data stub) in <head> so Dreamdata enters its built-in intercept mode instead of auto-initing
- Add init-dreamdata script verbatim to Layout.astro <head>
- Add loadDreamdata() to push analytics_storage consent signal via dataLayer
- Add loadDreamdataCL() to conditionally execute the CL snippet after consent
- Wire granted/denied signals into accept-all, essential-only, and save-preferences consent paths
- Update cookie-policy and privacy-policy pages to document Dreamdata