### PR TITLE
fix(cookie): close/cancel on settings modal now dismisses consent UI

### DIFF
--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -420,15 +420,19 @@ function loadRB2B() {
 
   customizeBtn.addEventListener('click', showSettingsModal);
   
-  cancelCustomizeBtn.addEventListener('click', () => {
+  function dismissAll() {
+    setCookie(COOKIE_NAME, 'essential-only');
+    setCookie(ANALYTICS_COOKIE, 'false');
+    setCookie(MARKETING_COOKIE, 'false');
     hideSettingsModal();
-    showBanner();
-  });
+    hideBanner();
+    (window as any).dataLayer = (window as any).dataLayer || [];
+    (window as any).dataLayer.push(['consent', 'update', { analytics_storage: 'denied' }]);
+    window.dispatchEvent(new CustomEvent('cookie-consent-changed', { detail: { all: false } }));
+  }
 
-  closeSettingsBtn.addEventListener('click', () => {
-    hideSettingsModal();
-    showBanner();
-  });
+  cancelCustomizeBtn.addEventListener('click', dismissAll);
+  closeSettingsBtn.addEventListener('click', dismissAll);
 
   savePreferencesBtn.addEventListener('click', () => {
     setCookie(COOKIE_NAME, 'customized');


### PR DESCRIPTION
X and Cancel buttons previously called showBanner(), trapping users in an infinite loop between the modal and the bottom banner. Both buttons now invoke dismissAll(), saving essential-only consent and closing everything — matching standard GDPR close-equals-reject behaviour.