### PR TITLE
fix(cookie): force new JS bundle hash to bust stale Cloudflare cache

### DIFF
--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -190,7 +190,7 @@
 </style>
 
 <script>
-  // Cookie management functionality
+  // Cookie management functionality (v2)
   const COOKIE_NAME = 'cookie-consent';
   const ANALYTICS_COOKIE = 'analytics-consent';
   const MARKETING_COOKIE = 'marketing-consent';


### PR DESCRIPTION
Trivial comment change to ensure Astro generates a new content-hashed bundle, guaranteeing all edge nodes serve the updated consent logic rather than the pre-fix version.